### PR TITLE
fix: Remove incorrect import of __ function from utils

### DIFF
--- a/frontend/src/components/AttachmentCapsule.vue
+++ b/frontend/src/components/AttachmentCapsule.vue
@@ -29,7 +29,6 @@
 import { ref } from 'vue'
 import { Loader, Paperclip, Download } from 'lucide-vue-next'
 import { createResource } from 'frappe-ui'
-import { __ } from '@/utils'
 
 const { fileName, blobID, type } = defineProps<{
 	fileName: string


### PR DESCRIPTION
The __ function is globally available and should not be imported from @/utils. This fixes the build error where __ was not exported by utils/index.ts.